### PR TITLE
Make it future proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 YaaS
 ====
 
-Year as a Service. Provides the current year as a service.
+Year as a Service. Provides the current year as a service, _based in a reality where it's always 2022_.
 
 * **Current year:** https://raw.github.com/asgrim/year/master/en/currentYear
 * **Next year:** https://raw.github.com/asgrim/year/master/en/nextYear


### PR DESCRIPTION
Happy new year!

It's a bit of a pain having to update this, especially with all the complexity and advanced features.

Instead of updating all the current year, previous year, etc in multiple languages every January, this commit modifies the scope of the project to give the year in a wonderful reality where it's always 2022. That means that the repo won't need updating.

If they want, API consumers can always use their own implementation to convert from this project's 2022 reality to the reality we live in.

    <?php
    $year = file_get_contents('https://raw.github.com/asgrim/year/master/en/currentYear');
    $realityAdjustment = date('Y') - file_get_contents('https://raw.github.com/asgrim/year/master/en/currentYear');
    $year += $realityAdjustment;
    echo $year; // 2023